### PR TITLE
Add peak detection and marching cubes

### DIFF
--- a/src/napari_skimage/__init__.py
+++ b/src/napari_skimage/__init__.py
@@ -1,4 +1,3 @@
-
 from ._version import version as __version__
 try:
     from ._version import version as __version__
@@ -14,6 +13,7 @@ from .skimage_morphology_widget import (connected_components_widget,
 from .skimage_restoration_widget import (rolling_ball_restoration_widget,
                                          denoise_nl_means_restoration_widget)
 from. mathsops import (simple_maths_widget, maths_image_pairs_widget, conversion_widget)
+from .skimage_detection_widget import (peak_local_max_widget, marching_cubes_widget)
 
 __all__ = (
     "farid_filter_widget",
@@ -34,4 +34,6 @@ __all__ = (
     "simple_maths_widget",
     "maths_image_pairs_widget",
     "conversion_widget",
+    "peak_local_max_widget",
+    "marching_cubes_widget",
 )

--- a/src/napari_skimage/__init__.py
+++ b/src/napari_skimage/__init__.py
@@ -13,7 +13,9 @@ from .skimage_morphology_widget import (connected_components_widget,
 from .skimage_restoration_widget import (rolling_ball_restoration_widget,
                                          denoise_nl_means_restoration_widget)
 from. mathsops import (simple_maths_widget, maths_image_pairs_widget, conversion_widget)
-from .skimage_detection_widget import (peak_local_max_widget, marching_cubes_widget)
+from .skimage_detection_widget import (peak_local_max_widget,
+                                       marching_cubes_widget,
+                                       marching_cubes_labels_widget)
 
 __all__ = (
     "farid_filter_widget",
@@ -36,4 +38,5 @@ __all__ = (
     "conversion_widget",
     "peak_local_max_widget",
     "marching_cubes_widget",
+    "marching_cubes_labels_widget",
 )

--- a/src/napari_skimage/_tests/test_detection_widgets.py
+++ b/src/napari_skimage/_tests/test_detection_widgets.py
@@ -1,5 +1,7 @@
 import numpy as np
-from napari_skimage.skimage_detection_widget import peak_local_max_widget, marching_cubes_widget
+from napari_skimage.skimage_detection_widget import (peak_local_max_widget,
+                                                     marching_cubes_widget,
+                                                     marching_cubes_labels_widget)
 from napari.layers import Image, Labels
 
 def test_peak_local_max_widget(make_napari_viewer):
@@ -17,19 +19,20 @@ def test_marching_cubes_widget(make_napari_viewer):
     viewer = make_napari_viewer()
     label_image = np.zeros((100, 100, 100), dtype=int)
     label_image[25:75, 25:75, 25:75] = 1
-    layer = viewer.add_labels(label_image)
+    layer = viewer.add_image(label_image)
 
     my_widget = marching_cubes_widget()
 
-    surface, _, _ = my_widget(viewer.layers[0])
+    surface, _, _ = my_widget(layer)
     vertices, faces = surface
     assert vertices.shape[1] == 3  # Ensure vertices are 3D
     assert faces.shape[1] == 3  # Ensure faces are triangles
     assert faces.dtype == np.int32  # Ensure faces are integer type
 
-    my_widget = marching_cubes_widget()
+    layer = viewer.add_labels(label_image)
+    my_widget = marching_cubes_labels_widget()
 
-    surface, _, _ = my_widget(viewer.layers[0], binarize=True)
+    surface, _, _ = my_widget(layer)
     vertices, faces = surface
     assert vertices.shape[1] == 3  # Ensure vertices are 3D
     assert faces.shape[1] == 3  # Ensure faces are triangles

--- a/src/napari_skimage/_tests/test_detection_widgets.py
+++ b/src/napari_skimage/_tests/test_detection_widgets.py
@@ -27,7 +27,7 @@ def test_marching_cubes_widget(make_napari_viewer):
     vertices, faces = surface
     assert vertices.shape[1] == 3  # Ensure vertices are 3D
     assert faces.shape[1] == 3  # Ensure faces are triangles
-    assert faces.dtype == np.int32  # Ensure faces are integer type
+    assert (faces.dtype == np.int32) | (faces.dtype == np.int64)  # Ensure faces are integer type
 
     layer = viewer.add_labels(label_image)
     my_widget = marching_cubes_labels_widget()
@@ -36,4 +36,4 @@ def test_marching_cubes_widget(make_napari_viewer):
     vertices, faces = surface
     assert vertices.shape[1] == 3  # Ensure vertices are 3D
     assert faces.shape[1] == 3  # Ensure faces are triangles
-    assert faces.dtype == np.int32  # Ensure faces are integer type
+    assert (faces.dtype == np.int32) | (faces.dtype == np.int64)  # Ensure faces are integer type

--- a/src/napari_skimage/_tests/test_detection_widgets.py
+++ b/src/napari_skimage/_tests/test_detection_widgets.py
@@ -1,0 +1,27 @@
+import numpy as np
+from napari_skimage.skimage_detection_widget import peak_local_max_widget, marching_cubes_widget
+from napari.layers import Image, Labels
+
+def test_peak_local_max_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+    random_image = np.random.random((100, 100))
+    layer = viewer.add_image(random_image)
+
+    my_widget = peak_local_max_widget()
+
+    points, _, _ = my_widget(viewer.layers[0])
+    assert points.shape[1] == 2  # Ensure points are 2D
+    assert points.shape[0] > 0  # Ensure some points are detected
+
+def test_marching_cubes_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+    random_labels = np.random.randint(0, 2, (100, 100, 100), dtype=np.uint8)
+    layer = viewer.add_labels(random_labels)
+
+    my_widget = marching_cubes_widget()
+
+    surface, _, _ = my_widget(viewer.layers[0])
+    vertices, faces = surface
+    assert vertices.shape[1] == 3  # Ensure vertices are 3D
+    assert faces.shape[1] == 3  # Ensure faces are triangles
+    assert faces.dtype == np.int32  # Ensure faces are integer type

--- a/src/napari_skimage/_tests/test_detection_widgets.py
+++ b/src/napari_skimage/_tests/test_detection_widgets.py
@@ -15,12 +15,21 @@ def test_peak_local_max_widget(make_napari_viewer):
 
 def test_marching_cubes_widget(make_napari_viewer):
     viewer = make_napari_viewer()
-    random_labels = np.random.randint(0, 2, (100, 100, 100), dtype=np.uint8)
-    layer = viewer.add_labels(random_labels)
+    label_image = np.zeros((100, 100, 100), dtype=int)
+    label_image[25:75, 25:75, 25:75] = 1
+    layer = viewer.add_labels(label_image)
 
     my_widget = marching_cubes_widget()
 
     surface, _, _ = my_widget(viewer.layers[0])
+    vertices, faces = surface
+    assert vertices.shape[1] == 3  # Ensure vertices are 3D
+    assert faces.shape[1] == 3  # Ensure faces are triangles
+    assert faces.dtype == np.int32  # Ensure faces are integer type
+
+    my_widget = marching_cubes_widget()
+
+    surface, _, _ = my_widget(viewer.layers[0], binarize=True)
     vertices, faces = surface
     assert vertices.shape[1] == 3  # Ensure vertices are 3D
     assert faces.shape[1] == 3  # Ensure faces are triangles

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -60,6 +60,12 @@ contributions:
     - id: napari-skimage.make_denoise_nl_means_restoration_widget
       python_name: napari_skimage.skimage_restoration_widget:denoise_nl_means_restoration_widget
       title: Make denoise nl means restoration widget
+    - id: napari-skimage.make_peak_local_max_widget
+      python_name: napari_skimage.skimage_detection_widget:peak_local_max_widget
+      title: Make Peak Local Max widget
+    - id: napari-skimage.make_marching_cubes_widget
+      python_name: napari_skimage.skimage_detection_widget:marching_cubes_widget
+      title: Make Marching Cubes widget
   widgets:
     - command: napari-skimage.make_farid_widget
       display_name: Farid filter
@@ -97,6 +103,10 @@ contributions:
       display_name: Rolling ball restoration
     - command: napari-skimage.make_denoise_nl_means_restoration_widget
       display_name: Denoise nl means restoration
+    - command: napari-skimage.make_peak_local_max_widget
+      display_name: Peak Local Max
+    - command: napari-skimage.make_marching_cubes_widget
+      display_name: Marching Cubes
 
   menus:
     napari/layers/filter:
@@ -109,6 +119,9 @@ contributions:
       - submenu: maths_submenu
     napari/layers/segment:
       - command: napari-skimage.make_connected_components_widget
+    napari/layers/layer_type:
+      - command: napari-skimage.make_peak_local_max_widget
+      - command: napari-skimage.make_marching_cubes_widget
     filtering_submenu:
       - command: napari-skimage.make_gaussian_widget
       - command: napari-skimage.make_median_widget

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -66,6 +66,9 @@ contributions:
     - id: napari-skimage.make_marching_cubes_widget
       python_name: napari_skimage.skimage_detection_widget:marching_cubes_widget
       title: Make Marching Cubes widget
+    - id: napari-skimage.make_marching_cubes_labels_widget
+      python_name: napari_skimage.skimage_detection_widget:marching_cubes_labels_widget
+      title: Make Marching Cubes (labels) widget
   widgets:
     - command: napari-skimage.make_farid_widget
       display_name: Farid filter
@@ -107,6 +110,8 @@ contributions:
       display_name: Peak Local Max
     - command: napari-skimage.make_marching_cubes_widget
       display_name: Marching Cubes
+    - command: napari-skimage.make_marching_cubes_labels_widget
+      display_name: Marching Cubes (labels)
 
   menus:
     napari/layers/filter:
@@ -122,6 +127,7 @@ contributions:
     napari/layers/layer_type:
       - command: napari-skimage.make_peak_local_max_widget
       - command: napari-skimage.make_marching_cubes_widget
+      - command: napari-skimage.make_marching_cubes_labels_widget
     filtering_submenu:
       - command: napari-skimage.make_gaussian_widget
       - command: napari-skimage.make_median_widget

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -24,8 +24,7 @@ def _on_init_peak_local_max(widget):
 
 def _on_init_marching_cubes(widget):
     label_widget = Label(value='')
-    func_name = '_'.join(widget.label.split(' ')[:-1])
-    label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.{func_name}\">skimage.measure.{func_name}</a>'
+    label_widget.value = '<a href=\"https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.marching_cubes\">skimage.measure.marching_cubes</a>'
     label_widget.native.setTextFormat(Qt.RichText)
     label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
     label_widget.native.setOpenExternalLinks(True)
@@ -60,24 +59,36 @@ def peak_local_max_widget(
 
 
 @magic_factory(
-    label_layer={'label': 'Labels'},
-    label={'label': 'Label'},
-    binarize={'label': 'Binarize'},
+    image_layer={'label': 'Image'},
+    level={'label': 'Level', 'min': 0.0, 'max': 65535},
     call_button="Apply Marching Cubes",
     widget_init=_on_init_marching_cubes
 )
 def marching_cubes_widget(
-    label_layer: Labels,
-    label: int = 1,
-    binarize: bool = False
+    image_layer: Image,
+    level: float = 0.5,
 ) -> napari.types.LayerDataTuple:
-    if binarize:
-        data = (label_layer.data > 0).astype(int)
-    else:
-        data = (label_layer.data == label).astype(int)
-    verts, faces, _, _ = marching_cubes(data, level=0.5)
+
+    verts, faces, _, _ = marching_cubes(image_layer.data, level=level)
     return (
         (verts, faces.astype(int)),
-        {'name': f'{label_layer.name}_surface'},
+        {'name': f'{image_layer.name}_surface'},
+        'surface'
+    )
+
+
+@magic_factory(
+    labels_layer={'label': 'Labels'},
+    call_button='Apply Marching Cubes',
+    widget_init=_on_init_marching_cubes
+)
+def marching_cubes_labels_widget(
+    labels_layer: Labels,
+) -> napari.types.LayerDataTuple:
+
+    verts, faces, _, _ = marching_cubes(labels_layer.data > 0, level=0.5)
+    return (
+        (verts, faces.astype(int)),
+        {'name': f'{labels_layer.name}_surface'},
         'surface'
     )

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING
+import numpy as np
+from magicgui import magic_factory
+from skimage.feature import peak_local_max
+from skimage.measure import marching_cubes
+from napari.layers import Image, Labels
+import napari.types
+
+if TYPE_CHECKING:
+    import napari
+
+@magic_factory(
+    image_layer={'label': 'Image'},
+    min_distance={'label': 'Minimum Distance'},
+    threshold_abs={'label': 'Threshold Absolute'},
+    call_button="Detect Local Maxima"
+)
+def peak_local_max_widget(
+    image_layer: Image,
+    min_distance: int = 1,
+    threshold_abs: float = 0
+) -> napari.types.LayerDataTuple:
+    coordinates = peak_local_max(image_layer.data, min_distance=min_distance, threshold_abs=threshold_abs)
+    return (
+        coordinates,
+        {'name': f'{image_layer.name}_local_maxima'},
+        'points'
+    )
+
+@magic_factory(
+    label_layer={'label': 'Labels'},
+    level={'label': 'Level'},
+    call_button="Apply Marching Cubes"
+)
+def marching_cubes_widget(
+    label_layer: Labels,
+    level: float = 0.0
+) -> napari.types.LayerDataTuple:
+    verts, faces, _, _ = marching_cubes(label_layer.data, level=level)
+    return (
+        (verts, faces.astype(int)),
+        {'name': f'{label_layer.name}_surface'},
+        'surface'
+    )

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -12,15 +12,20 @@ if TYPE_CHECKING:
 @magic_factory(
     image_layer={'label': 'Image'},
     min_distance={'label': 'Minimum Distance'},
-    threshold_abs={'label': 'Threshold Absolute'},
+    threshold_absolute={'label': 'Threshold Absolute'},
+    threshold_relative={'label': 'Threshold Relative', 'min': 0.0, 'max': 1.0},
     call_button="Detect Local Maxima"
 )
 def peak_local_max_widget(
     image_layer: Image,
-    min_distance: int = 1,
-    threshold_abs: float = 0
+    min_distance: int = 10,
+    threshold_absolute: float = 0,
+    threshold_relative: float = 0.0
 ) -> napari.types.LayerDataTuple:
-    coordinates = peak_local_max(image_layer.data, min_distance=min_distance, threshold_abs=threshold_abs)
+    coordinates = peak_local_max(image_layer.data,
+                                 min_distance=min_distance,
+                                 threshold_abs=threshold_absolute,
+                                 threshold_rel=threshold_relative)
     return (
         coordinates,
         {'name': f'{image_layer.name}_local_maxima'},

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -34,14 +34,20 @@ def peak_local_max_widget(
 
 @magic_factory(
     label_layer={'label': 'Labels'},
-    level={'label': 'Level'},
+    label={'label': 'Label'},
+    binarize={'label': 'Binarize'},
     call_button="Apply Marching Cubes"
 )
 def marching_cubes_widget(
     label_layer: Labels,
-    level: float = 0.0
+    label: float = 0.0,
+    binarize: bool = False
 ) -> napari.types.LayerDataTuple:
-    verts, faces, _, _ = marching_cubes(label_layer.data, level=level)
+    if binarize:
+        data = label_layer.data > 0
+    else:
+        data = label_layer.data == label
+    verts, faces, _, _ = marching_cubes(data, level=0.5)
     return (
         (verts, faces.astype(int)),
         {'name': f'{label_layer.name}_surface'},

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -45,11 +45,13 @@ def peak_local_max_widget(
     min_distance: int = 10,
     threshold_absolute: float = 0,
     threshold_relative: float = 0.0,
+    exclude_border: bool = True,
 ) -> napari.types.LayerDataTuple:
     coordinates = peak_local_max(image_layer.data,
                                  min_distance=min_distance,
                                  threshold_abs=threshold_absolute,
-                                 threshold_rel=threshold_relative)
+                                 threshold_rel=threshold_relative,
+                                 exclude_border=exclude_border)
     return (
         coordinates,
         {'name': f'{image_layer.name}_local_maxima'},

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @magic_factory(
     image_layer={'label': 'Image'},
     min_distance={'label': 'Minimum Distance'},
-    threshold_absolute={'label': 'Threshold Absolute'},
+    threshold_absolute={'label': 'Threshold Absolute', 'min': 0.0, 'max': 65535},
     threshold_relative={'label': 'Threshold Relative', 'min': 0.0, 'max': 1.0},
     call_button="Detect Local Maxima"
 )

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING
 import numpy as np
 from magicgui import magic_factory
+from qtpy.QtCore import Qt
+from magicgui.widgets import Label
 from skimage.feature import peak_local_max
 from skimage.measure import marching_cubes
 from napari.layers import Image, Labels
@@ -9,18 +11,40 @@ import napari.types
 if TYPE_CHECKING:
     import napari
 
+
+def _on_init_peak_local_max(widget):
+    label_widget = Label(value='')
+    func_name = '_'.join(widget.label.split(' ')[:-1])
+    label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.{func_name}\">skimage.feature.{func_name}</a>'
+    label_widget.native.setTextFormat(Qt.RichText)
+    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label_widget.native.setOpenExternalLinks(True)
+    widget.extend([label_widget])
+
+
+def _on_init_marching_cubes(widget):
+    label_widget = Label(value='')
+    func_name = '_'.join(widget.label.split(' ')[:-1])
+    label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.{func_name}\">skimage.measure.{func_name}</a>'
+    label_widget.native.setTextFormat(Qt.RichText)
+    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label_widget.native.setOpenExternalLinks(True)
+    widget.extend([label_widget])
+
+
 @magic_factory(
     image_layer={'label': 'Image'},
     min_distance={'label': 'Minimum Distance'},
     threshold_absolute={'label': 'Threshold Absolute', 'min': 0.0, 'max': 65535},
     threshold_relative={'label': 'Threshold Relative', 'min': 0.0, 'max': 1.0},
-    call_button="Detect Local Maxima"
+    call_button="Detect Local Maxima",
+    widget_init=_on_init_peak_local_max
 )
 def peak_local_max_widget(
     image_layer: Image,
     min_distance: int = 10,
     threshold_absolute: float = 0,
-    threshold_relative: float = 0.0
+    threshold_relative: float = 0.0,
 ) -> napari.types.LayerDataTuple:
     coordinates = peak_local_max(image_layer.data,
                                  min_distance=min_distance,
@@ -32,11 +56,13 @@ def peak_local_max_widget(
         'points'
     )
 
+
 @magic_factory(
     label_layer={'label': 'Labels'},
     label={'label': 'Label'},
     binarize={'label': 'Binarize'},
-    call_button="Apply Marching Cubes"
+    call_button="Apply Marching Cubes",
+    widget_init=_on_init_marching_cubes
 )
 def marching_cubes_widget(
     label_layer: Labels,

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -69,7 +69,7 @@ def marching_cubes_widget(
     level: float = 0.5,
 ) -> napari.types.LayerDataTuple:
 
-    verts, faces, _, _ = marching_cubes(image_layer.data, level=level)
+    verts, faces, _, _ = marching_cubes(image_layer.data, level=level, spacing=image_layer.scale)
     return (
         (verts, faces.astype(int)),
         {'name': f'{image_layer.name}_surface'},

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -40,13 +40,13 @@ def peak_local_max_widget(
 )
 def marching_cubes_widget(
     label_layer: Labels,
-    label: float = 0.0,
+    label: int = 1,
     binarize: bool = False
 ) -> napari.types.LayerDataTuple:
     if binarize:
-        data = label_layer.data > 0
+        data = (label_layer.data > 0).astype(int)
     else:
-        data = label_layer.data == label
+        data = (label_layer.data == label).astype(int)
     verts, faces, _, _ = marching_cubes(data, level=0.5)
     return (
         (verts, faces.astype(int)),


### PR DESCRIPTION
Fixes #3

Implement `peak_local_max` and `marching_cubes` algorithms in the project.

* Add `peak_local_max_widget` function in `src/napari_skimage/skimage_detection_widget.py` to detect local maxima in image layers and return points layer.
* Add `marching_cubes_widget` function in `src/napari_skimage/skimage_detection_widget.py` to apply marching cubes algorithm on labels layers and return surface layer.
* Update `src/napari_skimage/napari.yaml` to include commands and widgets for `peak_local_max_widget` and `marching_cubes_widget`.
* Update `src/napari_skimage/__init__.py` to import `peak_local_max_widget` and `marching_cubes_widget`.
* Add tests for `peak_local_max_widget` and `marching_cubes_widget` in `src/napari_skimage/_tests/test_detection_widgets.py`.

## Tests

- [x] Tested interactively
- [x] Tested manually from viewer