### PR TITLE
Upgrade the connected_components widget to have connectivity and background

### DIFF
--- a/src/napari_skimage/__init__.py
+++ b/src/napari_skimage/__init__.py
@@ -17,6 +17,7 @@ from. mathsops import (simple_maths_widget, maths_image_pairs_widget,
 from .skimage_detection_widget import (peak_local_max_widget,
                                        marching_cubes_widget,
                                        marching_cubes_labels_widget)
+from .skimage_label_widget import label_widget
 
 __all__ = (
     "farid_filter_widget",
@@ -41,4 +42,5 @@ __all__ = (
     "peak_local_max_widget",
     "marching_cubes_widget",
     "marching_cubes_labels_widget",
+    "label_widget",
 )

--- a/src/napari_skimage/__init__.py
+++ b/src/napari_skimage/__init__.py
@@ -8,8 +8,7 @@ from .skimage_filter_widget import (farid_filter_widget, prewitt_filter_widget,
                                     frangi_filter_widget, median_filter_widget,
                                     butterworth_filter_widget, RankFilterWidget)
 from .skimage_threshold_widget import threshold_widget, ManualThresholdWidget
-from .skimage_morphology_widget import (connected_components_widget,
-                                        binary_morphology_widget, morphology_widget)
+from .skimage_morphology_widget import (binary_morphology_widget, morphology_widget)
 from .skimage_restoration_widget import (rolling_ball_restoration_widget,
                                          denoise_nl_means_restoration_widget)
 from. mathsops import (simple_maths_widget, maths_image_pairs_widget,
@@ -30,7 +29,6 @@ __all__ = (
     "RankFilterWidget",
     "threshold_widget",
     "ManualThresholdWidget",
-    "connected_components_widget",
     "binary_morphology_widget",
     "morphology_widget",
     "rolling_ball_restoration_widget",

--- a/src/napari_skimage/_tests/test_basic_widgets.py
+++ b/src/napari_skimage/_tests/test_basic_widgets.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from napari_skimage.skimage_morphology_widget import (
     binary_morphology_widget,
-    connected_components_widget,
     morphology_widget
 )
 from napari_skimage.skimage_threshold_widget import threshold_widget, ManualThresholdWidget
@@ -86,17 +85,6 @@ def test_morphology_widget(make_napari_viewer):
 
         filtered, _, _ = my_widget(viewer.layers[0])
         assert filtered.data.shape == random_image.shape
-
-def test_connected_components_widget(make_napari_viewer):
-    viewer = make_napari_viewer()
-    random_image = np.random.randint(0, 10, (100, 100), dtype=np.uint8)
-    layer = viewer.add_labels(random_image)
-
-    # our widget will be a MagicFactory or FunctionGui instance
-    my_widget = connected_components_widget()
-
-    filtered, _, _ = my_widget(viewer.layers[0])
-    assert filtered.data.shape == random_image.shape
 
 def test_thresholding_widget(make_napari_viewer):
     viewer = make_napari_viewer()

--- a/src/napari_skimage/_tests/test_basic_widgets.py
+++ b/src/napari_skimage/_tests/test_basic_widgets.py
@@ -8,6 +8,7 @@ from napari_skimage.skimage_morphology_widget import (
 from napari_skimage.skimage_threshold_widget import threshold_widget, ManualThresholdWidget
 import napari_skimage.skimage_filter_widget as sfw
 import napari_skimage.mathsops as nsm
+from napari_skimage.skimage_label_widget import label_widget
 
 # single fun test
 def test_farid_filter_widget(make_napari_viewer):
@@ -179,3 +180,19 @@ def test_conversion_widget(make_napari_viewer):
 
         filtered, _, _ = my_widget(viewer.layers[0])
         assert filtered.data.shape == random_image.shape
+
+def test_label_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+    binary = np.array([[0, 0, 0, 0],
+                             [0, 1, 0, 0],
+                             [0, 0, 0, 0],
+                             [0, 0, 1, 0],
+                             [0, 0, 0, 0]])
+    layer = viewer.add_labels(binary)
+
+    # our widget will be a MagicFactory or FunctionGui instance
+    my_widget = label_widget()
+    my_widget()
+
+    assert viewer.layers[1].data.shape == layer.data.shape
+    assert viewer.layers[1].data.max() == 2

--- a/src/napari_skimage/_tests/test_basic_widgets.py
+++ b/src/napari_skimage/_tests/test_basic_widgets.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 
 from napari_skimage.skimage_morphology_widget import (
@@ -169,18 +170,81 @@ def test_conversion_widget(make_napari_viewer):
         filtered, _, _ = my_widget(viewer.layers[0])
         assert filtered.data.shape == random_image.shape
 
-def test_label_widget(make_napari_viewer):
+@pytest.mark.parametrize(
+    "labels_layer, background",
+    [
+        # 2D binary array with background 0
+        (
+            np.array([
+                [0, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 0],
+                [0, 0, 1, 0],
+                [0, 0, 0, 0],
+            ]),
+            0,
+        ),
+        # 3D binary array with background 0
+        (
+            np.array([
+                [
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 1, 0],
+                    [0, 0, 0, 0],
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                ],
+            ]),
+            0,
+        ),
+        # 2D labels array with background 1
+        (
+            np.array([
+                [0, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 0],
+                [0, 0, 2, 0],
+                [0, 0, 0, 0],
+            ]),
+            1,
+        ),
+    ],
+)
+def test_label_widget(make_napari_viewer, labels_layer, background):
     viewer = make_napari_viewer()
-    binary = np.array([[0, 0, 0, 0],
-                             [0, 1, 0, 0],
-                             [0, 0, 0, 0],
-                             [0, 0, 1, 0],
-                             [0, 0, 0, 0]])
-    layer = viewer.add_labels(binary)
+    layer = viewer.add_labels(labels_layer)
 
-    # our widget will be a MagicFactory or FunctionGui instance
     my_widget = label_widget()
+    # check that max connectivity matches data.ndim
+    assert my_widget.connectivity.max == layer.data.ndim
+    
+    # set and check the background value
+    my_widget.background.value = background
+    assert my_widget.background.value == background
+
     my_widget()
 
+    # check the output layer is correct
     assert viewer.layers[1].data.shape == layer.data.shape
     assert viewer.layers[1].data.max() == 2
+
+    # check that the first (corner) pixel is correctly labeled
+    # taking into account the background value
+    if background == 0:
+        assert viewer.layers[1].data.ravel()[0] == 0
+    else:
+        assert viewer.layers[1].data.ravel()[0] == 1

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -39,12 +39,9 @@ contributions:
     - id: napari-skimage.make_morphology_widget
       python_name: napari_skimage.skimage_morphology_widget:morphology_widget
       title: Make morphology widget
-    - id: napari-skimage.make_connected_components_widget
-      python_name: napari_skimage.skimage_morphology_widget:connected_components_widget
-      title: Make connected components widget
     - id: napari-skimage.make_label_widget
       python_name: napari_skimage.skimage_label_widget:label_widget
-      title: Make connected components widget
+      title: Make label connected components widget
     - id: napari-skimage.make_maths_image_pairs_widget
       python_name: napari_skimage.mathsops:maths_image_pairs_widget
       title: Make image pairs maths widget
@@ -98,10 +95,8 @@ contributions:
       display_name: Binary Morphology
     - command: napari-skimage.make_morphology_widget
       display_name: Morphology
-    - command: napari-skimage.make_connected_components_widget
-      display_name: Connected components
     - command: napari-skimage.make_label_widget
-      display_name: Label
+      display_name: Label connected components
     - command: napari-skimage.make_simple_maths_widget
       display_name: Simple maths
     - command: napari-skimage.make_maths_crop_widget
@@ -133,8 +128,6 @@ contributions:
       - submenu: morphology_submenu
       - submenu: maths_submenu
     napari/layers/segment:
-      - command: napari-skimage.make_connected_components_widget
-    napari/layers/measure:
       - command: napari-skimage.make_label_widget
     napari/layers/layer_type:
       - command: napari-skimage.make_peak_local_max_widget

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -42,6 +42,9 @@ contributions:
     - id: napari-skimage.make_connected_components_widget
       python_name: napari_skimage.skimage_morphology_widget:connected_components_widget
       title: Make connected components widget
+    - id: napari-skimage.make_label_widget
+      python_name: napari_skimage.skimage_label_widget:label_widget
+      title: Make connected components widget
     - id: napari-skimage.make_maths_image_pairs_widget
       python_name: napari_skimage.mathsops:maths_image_pairs_widget
       title: Make image pairs maths widget
@@ -97,6 +100,8 @@ contributions:
       display_name: Morphology
     - command: napari-skimage.make_connected_components_widget
       display_name: Connected components
+    - command: napari-skimage.make_label_widget
+      display_name: Label
     - command: napari-skimage.make_simple_maths_widget
       display_name: Simple maths
     - command: napari-skimage.make_maths_crop_widget
@@ -129,6 +134,8 @@ contributions:
       - submenu: maths_submenu
     napari/layers/segment:
       - command: napari-skimage.make_connected_components_widget
+    napari/layers/measure:
+      - command: napari-skimage.make_label_widget
     napari/layers/layer_type:
       - command: napari-skimage.make_peak_local_max_widget
       - command: napari-skimage.make_marching_cubes_widget

--- a/src/napari_skimage/skimage_label_widget.py
+++ b/src/napari_skimage/skimage_label_widget.py
@@ -24,9 +24,14 @@ def _on_init_label(widget: "Widget") -> None:
     # Dynamically update the max value of connectivity based on labels_layer.ndim
     @widget.labels_layer.changed.connect
     def update_connectivity_range(event: object) -> None:
-        """Update the max value of connectivity based on labels_layer.ndim"""
+        """Update the max value of connectivity based on labels_layer.ndim
+        
+        Also ensures that the default value of connectivity is set to the
+        ndim, which matches the skimage default behavior."""
         if widget.labels_layer.value is not None:
+            widget.connectivity.value = widget.labels_layer.value.data.ndim
             widget.connectivity.max = widget.labels_layer.value.data.ndim
+
 
     update_connectivity_range(None)  # Initialize the range
 

--- a/src/napari_skimage/skimage_label_widget.py
+++ b/src/napari_skimage/skimage_label_widget.py
@@ -1,0 +1,56 @@
+from typing import TYPE_CHECKING
+
+import napari.types
+from magicgui import magic_factory
+from magicgui.widgets import Label
+from napari.layers import Labels
+from napari.utils.notifications import show_info
+from qtpy.QtCore import Qt
+from skimage.measure import label
+
+if TYPE_CHECKING:
+    import napari
+    from magicgui.widgets import Widget
+
+
+def _on_init_label(widget: "Widget") -> None:
+    label_widget = Label(value="")
+    label_widget.value = '<a href="https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.label">skimage.measure.label</a>'
+    label_widget.native.setTextFormat(Qt.RichText)
+    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label_widget.native.setOpenExternalLinks(True)
+    widget.extend([label_widget])
+
+    # Dynamically update the max value of connectivity based on labels_layer.ndim
+    @widget.labels_layer.changed.connect
+    def update_connectivity_range(event: object) -> None:
+        """Update the max value of connectivity based on labels_layer.ndim"""
+        if widget.labels_layer.value is not None:
+            widget.connectivity.max = widget.labels_layer.value.data.ndim
+
+    update_connectivity_range(None)  # Initialize the range
+
+
+@magic_factory(
+    labels_layer={"label": "Labels Layer"},
+    connectivity={"label": "Connectivity", "min": 1, "step": 1},
+    call_button="Label connected components",
+    widget_init=_on_init_label,
+)
+def label_widget(
+    labels_layer: Labels,
+    connectivity: int = 1,
+    background: int = 0,
+) -> napari.types.LayerDataTuple:
+    labeled_array, number = label(
+        labels_layer.data,
+        connectivity=connectivity,
+        background=background,
+        return_num=True,
+    )
+    show_info(f"Labeled {number} regions")
+    return (
+        (labeled_array,),
+        {"name": f"{labels_layer.name}_labeled"},
+        "labels",
+    )

--- a/src/napari_skimage/skimage_morphology_widget.py
+++ b/src/napari_skimage/skimage_morphology_widget.py
@@ -17,17 +17,6 @@ provided via the _on_init function which first checks if the widget is for binar
 and then creates the appropriate link.
 """
 
-@magic_factory(
-    label_layer={'label': 'Labels'},
-    call_button="Find connected components"
- )
-def connected_components_widget(
-    label_layer: Labels) -> napari.types.LayerDataTuple:
-    return (
-        sm.label(label_layer.data),
-        {'name': f'{label_layer.name}_labels'},
-        'labels')
-
 def _on_init(widget):
     label_widget = Label(value='')   
 


### PR DESCRIPTION
So first to be totally honest, I totally missed the existence of the connected_components widget because I was searching for `skimage.measure.label`
So I started implementing my own, as a quick contribution, because I was already showing people the filters and thresholds and wanted a quick GUI way to count objects.
Then I realized it existed!

That said, I think this refactor/breaking it out like this is worth it, because skimage.measure is the canonical location of the function. In fact the import in skimage.morphology imports from skimage.measure.

Beyond the refactor, this PR adds a few improvements:
It also adds a connectivity option, which checks the ndim of the layer, as well as the ability to use the background kwarg. Finally, and part of my original motivation, it displays the number of components.
And I upgraded the test a tiny bit to check the new features.

If you want me to just "enhance" the existing widget I'm happy to do that in an alternative PR.

