### PR TITLE
Add skimage.measure.regionprops widget

### DIFF
--- a/src/napari_skimage/_tests/test_regionprops_widget.py
+++ b/src/napari_skimage/_tests/test_regionprops_widget.py
@@ -1,0 +1,169 @@
+import numpy as np
+import pandas as pd
+
+from napari_skimage.skimage_regionprops_widget import (
+    only_2d_properties,
+    regionprops_widget,
+)
+
+
+def test_regionprops_widget(make_napari_viewer):
+    # Create a napari viewer
+    viewer = make_napari_viewer()
+
+    # Test data
+    intensity_image = np.array(
+        [
+            [0, 0, 0, 0],
+            [0, 6, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 7, 0],
+            [0, 0, 0, 0],
+        ]
+    )
+    labels_image = np.array(
+        [
+            [0, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 2, 0],
+            [0, 0, 0, 0],
+        ]
+    )
+
+    # Add the test data to the viewer
+    intensity_layer = viewer.add_image(intensity_image, name="Intensity Image")
+    labels_layer = viewer.add_labels(labels_image, name="Labels Layer")
+
+    # Create the regionprops widget
+    widget = regionprops_widget()
+
+    # Select properties to compute
+    widget.properties.value = ["area", "label", "intensity_mean"]
+
+    # Call the widget with the test layers
+    widget(
+        image_layer=intensity_layer,
+        labels_layer=labels_layer,
+        properties=widget.properties.value,
+    )
+
+    # Check that the results table is created
+    assert hasattr(widget, "results_table")
+
+    # Check the contents of the results table
+    results_df = widget.results_table.to_dataframe()
+    expected_df = pd.DataFrame(
+        {
+            "area": [1.0, 1.0],
+            "intensity_mean": [6.0, 7.0],
+            "label": [1.0, 2.0],
+        }
+    )
+    pd.testing.assert_frame_equal(results_df, expected_df)
+
+    # Check that the dock widget is added to the viewer
+    assert hasattr(widget, "_results_dock_widget")
+    assert widget._results_dock_widget.widget is not None
+
+
+def test_2d_vs_3d_properties(make_napari_viewer):
+    # Create a napari viewer
+    viewer = make_napari_viewer()
+
+    # Test 2D data
+    labels_2d = np.array(
+        [
+            [0, 0, 0],
+            [0, 1, 0],
+            [0, 0, 0],
+        ]
+    )
+    labels_layer_2d = viewer.add_labels(labels_2d, name="2D Labels")
+
+    # Test 3D data
+    labels_3d = np.array(
+        [
+            [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+            [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
+            [[0, 0, 0], [0, 2, 0], [0, 0, 0]],
+        ]
+    )
+    labels_layer_3d = viewer.add_labels(labels_3d, name="3D Labels")
+
+    # Create the regionprops widget
+    widget = regionprops_widget()
+
+    # Check properties for 2D input
+    widget.labels_layer.value = labels_layer_2d
+    widget.properties.reset_choices()
+    properties_2d = widget.properties.choices
+    for prop in only_2d_properties:
+        assert prop in properties_2d, (
+            f"Property '{prop}' should be available for 2D input."
+        )
+
+    # Check properties for 3D input
+    widget.labels_layer.value = labels_layer_3d
+    widget.properties.reset_choices()
+    properties_3d = widget.properties.choices
+    for prop in only_2d_properties:
+        assert prop not in properties_3d, (
+            f"Property '{prop}' should not be available for 3D input."
+        )
+
+
+def test_analyze_button_state(make_napari_viewer):
+    # Create a napari viewer
+    viewer = make_napari_viewer()
+
+    # Test data
+    intensity_image = np.array(
+        [
+            [0, 0, 0],
+            [0, 6, 0],
+            [0, 0, 0],
+        ]
+    )
+    labels_image = np.array(
+        [
+            [0, 0, 0],
+            [0, 1, 0],
+            [0, 0, 0],
+        ]
+    )
+    mismatched_image = np.array(
+        [
+            [0, 0],
+            [0, 6],
+        ]
+    )
+
+    # Add the test data to the viewer
+    intensity_layer = viewer.add_image(intensity_image, name="Intensity Image")
+
+    # Create the regionprops widget
+    widget = regionprops_widget()
+
+    # Only image layer -> button disabled
+    assert len(viewer.layers) == 1
+    widget.image_layer.value = intensity_layer
+    assert not widget.call_button.enabled
+
+    # Add labels layer and mismatched image
+    labels_layer = viewer.add_labels(labels_image, name="Labels Layer")
+    mismatched_layer = viewer.add_image(
+        mismatched_image, name="Mismatched Image"
+    )
+    widget.image_layer.reset_choices()
+    widget.labels_layer.reset_choices()
+
+    # Both layers selected with matching shapes -> button enabled
+    assert widget.image_layer.value == intensity_layer
+    widget.labels_layer.value = labels_layer
+    assert widget.call_button.enabled
+
+    # CBoth layers selected with mismatched shapes -> button disabled
+    widget.labels_layer.value = labels_layer
+    widget.image_layer.value = mismatched_layer
+    assert not widget.call_button.enabled

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -72,6 +72,9 @@ contributions:
     - id: napari-skimage.make_marching_cubes_labels_widget
       python_name: napari_skimage.skimage_detection_widget:marching_cubes_labels_widget
       title: Make Marching Cubes (labels) widget
+    - id: napari-skimage.make_regionprops_widget
+      python_name: napari_skimage.skimage_regionprops_widget:regionprops_widget
+      title: Make regionprops widget
   widgets:
     - command: napari-skimage.make_farid_widget
       display_name: Farid filter
@@ -117,6 +120,8 @@ contributions:
       display_name: Marching Cubes
     - command: napari-skimage.make_marching_cubes_labels_widget
       display_name: Marching Cubes (labels)
+    - command: napari-skimage.make_regionprops_widget
+      display_name: Regionprops (labels)
 
   menus:
     napari/layers/filter:

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -132,6 +132,8 @@ contributions:
       - submenu: thresholding_submenu
       - submenu: morphology_submenu
       - submenu: maths_submenu
+    napari/layers/measure:
+      - command: napari-skimage.make_regionprops_widget
     napari/layers/segment:
       - command: napari-skimage.make_connected_components_widget
     napari/layers/layer_type:

--- a/src/napari_skimage/skimage_regionprops_widget.py
+++ b/src/napari_skimage/skimage_regionprops_widget.py
@@ -1,0 +1,140 @@
+from typing import TYPE_CHECKING
+from magicgui import magic_factory
+from magicgui.widgets import Table, Label
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QAbstractItemView
+from skimage.measure import regionprops_table
+from skimage.measure._regionprops import PROPS
+import pandas as pd
+from napari.layers import Image, Labels
+import napari
+import napari.types
+from napari.utils.notifications import show_warning
+
+if TYPE_CHECKING:
+    from magicgui.widgets import Widget
+
+# Get the list of available properties for RegionProperties
+available_properties = set(PROPS.values())
+
+# Hard-code the properties that are only valid for 2D images
+only_2d_properties = {
+    "eccentricity",
+    "moments_hu",
+    "orientation",
+    "perimeter",
+    "perimeter_crofton",
+    "moments_weighted_hu",
+}
+
+valid_properties_3d = available_properties - only_2d_properties
+
+
+def _on_init(widget: "Widget"):
+    """Initialize the widget, add a hyperlink, and set up connections."""
+    # Add a hyperlink to the documentation
+    label_widget = Label(value="")
+    label_widget.value = '<a href="https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.regionprops_table">skimage.measure.regionprops_table</a>'
+    label_widget.native.setTextFormat(Qt.RichText)
+    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label_widget.native.setOpenExternalLinks(True)
+    widget.extend([label_widget])
+
+    # Define a function to get valid properties dynamically
+    def get_valid_properties(widget: "Widget"):
+        labels_layer = widget.labels_layer.value
+        if labels_layer:
+            is_2d = labels_layer.data.ndim == 2
+            return sorted(available_properties) if is_2d else sorted(valid_properties_3d)
+        else:
+            return []
+
+    # Update the properties choices dynamically
+    def update_properties_choices(event: object):
+        widget.properties.choices = []
+        widget.properties.reset_choices()
+
+    # Enable or disable the Analyze button based on input validation
+    def update_analyze_button_state(event: object):
+        labels_layer = widget.labels_layer.value
+        image_layer = widget.image_layer.value
+
+        if labels_layer and image_layer:
+            shapes_match = labels_layer.data.shape == image_layer.data.shape
+            if not shapes_match:
+                show_warning(
+                    "Shape mismatch: Labels Layer and Intensity Image must have the same shape."
+                )
+            widget.call_button.enabled = shapes_match
+        else:
+            widget.call_button.enabled = False
+
+    # Connect the signals to the update functions
+    widget.labels_layer.changed.connect(update_properties_choices)
+    widget.image_layer.changed.connect(update_properties_choices)
+    widget.labels_layer.changed.connect(update_analyze_button_state)
+    widget.image_layer.changed.connect(update_analyze_button_state)
+
+    # initialize Select widget and button state
+    widget.properties._default_choices = lambda _: get_valid_properties(widget)
+    update_properties_choices(widget)
+    update_analyze_button_state(widget)
+
+@magic_factory(
+    image_layer={"label": "Intensity Image Layer"},
+    labels_layer={"label": "Labels Layer"},
+    properties={
+        "label": "Properties",
+        "widget_type": "Select",
+        "allow_multiple": True,
+    },
+    call_button="Analyze",
+    widget_init=_on_init,
+)
+def regionprops_widget(
+    image_layer: Image, labels_layer: Labels, properties: list[str]
+) -> napari.types.LayerDataTuple:
+    """Widget to compute regionprops_table and display results."""
+    if labels_layer.data.shape != image_layer.data.shape:
+        show_warning("Labels Layer and Intensity Image must have the same shape.")
+        return
+
+    # Compute regionprops_table
+    props = regionprops_table(
+        label_image=labels_layer.data,
+        intensity_image=image_layer.data,
+        properties=properties,
+        spacing=image_layer.scale,
+    )
+
+    # Convert to DataFrame
+    results_df = pd.DataFrame(props)
+
+    viewer =  napari.current_viewer()
+     # Check if the dock widget exists and is still valid
+    if (
+        not hasattr(regionprops_widget, "_results_dock_widget")
+        or regionprops_widget._results_dock_widget.widget is None
+    ):
+        regionprops_widget.results_table = Table(value=results_df, name="Results Table")
+        regionprops_widget.results_table.read_only = True
+
+        regionprops_widget._results_dock_widget = viewer.window.add_dock_widget(
+            regionprops_widget.results_table, area="bottom", name="Results Table"
+        )
+    else:
+        try:
+            regionprops_widget.results_table.value = results_df
+            regionprops_widget.results_table.read_only = True
+
+            regionprops_widget._results_dock_widget.show()
+        except RuntimeError:
+            regionprops_widget.results_table = Table(
+                value=results_df, name="Results Table"
+            )
+            regionprops_widget.results_table.read_only = True
+
+            regionprops_widget._results_dock_widget = viewer.window.add_dock_widget(
+                regionprops_widget.results_table, area="bottom", name="Results Table"
+            )
+    

--- a/src/napari_skimage/skimage_regionprops_widget.py
+++ b/src/napari_skimage/skimage_regionprops_widget.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import napari
 import napari.types
@@ -41,7 +41,7 @@ def _on_init(widget: "Widget") -> None:
     widget.extend([label_widget])
 
     # Define a function to get valid properties dynamically
-    def get_valid_properties(widget: "Widget"):
+    def get_valid_properties(widget: "Widget") -> Union(list, None):
         labels_layer = widget.labels_layer.value
         if labels_layer:
             is_2d = labels_layer.data.ndim == 2
@@ -55,12 +55,12 @@ def _on_init(widget: "Widget") -> None:
             return []
 
     # Update the properties choices dynamically
-    def update_properties_choices(event: object):
+    def update_properties_choices(event: object) -> None:
         widget.properties.choices = []
         widget.properties.reset_choices()
 
     # Enable or disable the Analyze button based on input validation
-    def update_analyze_button_state(event: object):
+    def update_analyze_button_state(event: object) -> None:
         labels_layer = widget.labels_layer.value
         image_layer = widget.image_layer.value
 
@@ -100,7 +100,7 @@ def _on_init(widget: "Widget") -> None:
     widget_init=_on_init,
 )
 def regionprops_widget(
-    labels_layer: Labels, image_layer: Image | None, properties: list[str]
+    labels_layer: Labels, image_layer: Union(Image, None), properties: list[str]
 ) -> napari.types.LayerDataTuple:
     """Widget to compute regionprops_table and display results."""
 
@@ -111,7 +111,7 @@ def regionprops_widget(
         )
         return
 
-    # Check for an image layer. If it's absent, 
+    # Check for an image layer. If it's absent,
     if image_layer:
         image_layer_data = image_layer.data
         spacing = image_layer.scale

--- a/src/napari_skimage/skimage_regionprops_widget.py
+++ b/src/napari_skimage/skimage_regionprops_widget.py
@@ -1,15 +1,15 @@
 from typing import TYPE_CHECKING
-from magicgui import magic_factory
-from magicgui.widgets import Table, Label
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QAbstractItemView
-from skimage.measure import regionprops_table
-from skimage.measure._regionprops import PROPS
-import pandas as pd
-from napari.layers import Image, Labels
+
 import napari
 import napari.types
+import pandas as pd
+from magicgui import magic_factory
+from magicgui.widgets import Label, Table
+from napari.layers import Image, Labels
 from napari.utils.notifications import show_warning
+from qtpy.QtCore import Qt
+from skimage.measure import regionprops_table
+from skimage.measure._regionprops import PROPS
 
 if TYPE_CHECKING:
     from magicgui.widgets import Widget
@@ -45,7 +45,11 @@ def _on_init(widget: "Widget"):
         labels_layer = widget.labels_layer.value
         if labels_layer:
             is_2d = labels_layer.data.ndim == 2
-            return sorted(available_properties) if is_2d else sorted(valid_properties_3d)
+            return (
+                sorted(available_properties)
+                if is_2d
+                else sorted(valid_properties_3d)
+            )
         else:
             return []
 
@@ -80,6 +84,7 @@ def _on_init(widget: "Widget"):
     update_properties_choices(widget)
     update_analyze_button_state(widget)
 
+
 @magic_factory(
     image_layer={"label": "Intensity Image Layer"},
     labels_layer={"label": "Labels Layer"},
@@ -96,7 +101,9 @@ def regionprops_widget(
 ) -> napari.types.LayerDataTuple:
     """Widget to compute regionprops_table and display results."""
     if labels_layer.data.shape != image_layer.data.shape:
-        show_warning("Labels Layer and Intensity Image must have the same shape.")
+        show_warning(
+            "Labels Layer and Intensity Image must have the same shape."
+        )
         return
 
     # Compute regionprops_table
@@ -110,17 +117,23 @@ def regionprops_widget(
     # Convert to DataFrame
     results_df = pd.DataFrame(props)
 
-    viewer =  napari.current_viewer()
-     # Check if the dock widget exists and is still valid
+    viewer = napari.current_viewer()
+    # Check if the dock widget exists and is still valid
     if (
         not hasattr(regionprops_widget, "_results_dock_widget")
         or regionprops_widget._results_dock_widget.widget is None
     ):
-        regionprops_widget.results_table = Table(value=results_df, name="Results Table")
+        regionprops_widget.results_table = Table(
+            value=results_df, name="Results Table"
+        )
         regionprops_widget.results_table.read_only = True
 
-        regionprops_widget._results_dock_widget = viewer.window.add_dock_widget(
-            regionprops_widget.results_table, area="bottom", name="Results Table"
+        regionprops_widget._results_dock_widget = (
+            viewer.window.add_dock_widget(
+                regionprops_widget.results_table,
+                area="bottom",
+                name="Results Table",
+            )
         )
     else:
         try:
@@ -134,7 +147,10 @@ def regionprops_widget(
             )
             regionprops_widget.results_table.read_only = True
 
-            regionprops_widget._results_dock_widget = viewer.window.add_dock_widget(
-                regionprops_widget.results_table, area="bottom", name="Results Table"
+            regionprops_widget._results_dock_widget = (
+                viewer.window.add_dock_widget(
+                    regionprops_widget.results_table,
+                    area="bottom",
+                    name="Results Table",
+                )
             )
-    

--- a/src/napari_skimage/skimage_regionprops_widget.py
+++ b/src/napari_skimage/skimage_regionprops_widget.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional
 
 import napari
 import napari.types
@@ -41,7 +41,7 @@ def _on_init(widget: "Widget") -> None:
     widget.extend([label_widget])
 
     # Define a function to get valid properties dynamically
-    def get_valid_properties(widget: "Widget") -> Union(list, None):
+    def get_valid_properties(widget: "Widget") -> Optional[list]:
         labels_layer = widget.labels_layer.value
         if labels_layer:
             is_2d = labels_layer.data.ndim == 2
@@ -100,7 +100,7 @@ def _on_init(widget: "Widget") -> None:
     widget_init=_on_init,
 )
 def regionprops_widget(
-    labels_layer: Labels, image_layer: Union(Image, None), properties: list[str]
+    labels_layer: Labels, image_layer: Optional[Image], properties: list[str]
 ) -> napari.types.LayerDataTuple:
     """Widget to compute regionprops_table and display results."""
 


### PR DESCRIPTION
Closes https://github.com/guiwitz/napari-skimage/issues/2

This is a very basic regionprops widget using just magicgui.
It gives access to all the properties for 2d or 3d and creates a magicgui Table.
Importantly, it sets the `spacing` kwarg from the image layer scale.

This was spurred by an end-user and a prep for a tutorial, so it's the real basics, but it covers the needed functionality.
Now a whole pipeline is available:
- filter
- threshold
- label
- regionprops

I added tests to cover the behaviors, like 2d vs 3d properties and button enablement.

Future nice to haves would be a button to copy the table with the headers (Qt doesn't select the headers) and a button to export to csv. There are not hard to implement, just not sure where to put them. Maybe under the analyze button?