### PR TITLE
Some suggestions to the region props Table PR

### DIFF
--- a/src/napari_skimage/skimage_regionprops_widget.py
+++ b/src/napari_skimage/skimage_regionprops_widget.py
@@ -89,16 +89,22 @@ def _on_init(widget: "Widget") -> None:
             widget.labels_layer.value.selected_label = label
 
     def save_table(event: object):
-        
-        widget.results_table.to_dataframe().to_csv(
-            QFileDialog.getSaveFileName(
+        # get file path from user
+        file_path = QFileDialog.getSaveFileName(
                 widget.native,
                 "Save Results",
                 ".",
                 "CSV Files (*.csv);;All Files (*)",
-            )[0],
-            index=False,
-        )
+            )[0]
+
+        # if the user cancels the dialog, file_path will be None, so we return
+        if not file_path:
+            return
+
+        widget.results_table.to_dataframe().to_csv(
+                file_path,
+                index=False,
+            )
     
     # initialize table
     widget.results_table = Table(name="Results Table")

--- a/src/napari_skimage/skimage_regionprops_widget.py
+++ b/src/napari_skimage/skimage_regionprops_widget.py
@@ -61,8 +61,16 @@ def _on_init(widget: "Widget") -> None:
 
     # Update the properties choices dynamically
     def update_properties_choices(event: object) -> None:
+        previously_selected_properties = widget.properties.value
         widget.properties.choices = []
         widget.properties.reset_choices()
+        try:
+            widget.properties.value = previously_selected_properties
+        # if you switch from 2D to 3D, the properties will be different
+        # and the previously selected properties might not be valid,
+        # so then reset them
+        except ValueError:
+            widget.properties.value = []
 
     # Enable or disable the Analyze button based on input validation
     def update_analyze_button_state(event: object) -> None:

--- a/src/napari_skimage/skimage_regionprops_widget.py
+++ b/src/napari_skimage/skimage_regionprops_widget.py
@@ -2,12 +2,13 @@ from typing import TYPE_CHECKING, Optional
 
 import napari
 import napari.types
+import numpy as np
 import pandas as pd
 from qtpy.QtWidgets import QFileDialog
 from magicgui import magic_factory
 from magicgui.widgets import Label, Table, Button
 from napari.layers import Image, Labels
-from napari.utils.notifications import show_warning
+from napari.utils.notifications import show_info, show_warning
 from qtpy.QtCore import Qt
 from skimage.measure import regionprops_table
 from skimage.measure._regionprops import PROPS, _require_intensity_image
@@ -90,11 +91,15 @@ def _on_init(widget: "Widget") -> None:
             widget.call_button.enabled = False
 
     def clicked_table(event: object):
+        row = widget.results_table.native.currentRow()
         if "label" in widget.results_table.column_headers:
-            row = widget.results_table.native.currentRow()
             label = int(widget.results_table["label"][row])
-            print("Table clicked, set label", label)
-            widget.labels_layer.value.selected_label = label
+        else:
+            # If the label column is not present, use the row index
+            # plus one to account for zero-based indexing
+            label = np.unique(widget.labels_layer.value.data)[row+1]
+        show_info(f"Table clicked, set label: {label}")
+        widget.labels_layer.value.selected_label = label
 
     def save_table(event: object):
         # get file path from user


### PR DESCRIPTION
This PR has some small suggestions as a PR to #10 

1. I noticed that if you cancel the Save dialog you get a traceback -- this is because when you cancel the dialog it returns None and the pandas method doesn't like that.
2. I thought the whole Table -> selected label just didn't work, until I realized it was literally using the Label **column**. In this PR I add a fallback to just get the label via np.unique. The alternative would be to by default include the Label column and append the others.
3. As I was testing I noticed when switching layers the choices get reset -- this is because of the 2D/3D thing. It was annoying because sometimes you may want to run the same props calcs on several layers in a row. This works! but you need to keep respecting choices. So I added a try/except to keep the choices, which resets