### PR TITLE
added type annotation for median filter

### DIFF
--- a/src/napari_skimage/skimage_filter_widget.py
+++ b/src/napari_skimage/skimage_filter_widget.py
@@ -36,7 +36,7 @@ def _on_init(widget):
         widget_init=_on_init
         )
 def farid_filter_widget(
-    image_layer: Image, mode='reflect') -> napari.types.LayerDataTuple:
+    image_layer: Image, mode: str ='reflect') -> napari.types.LayerDataTuple:
     return (
         sf.farid(image_layer.data, mode=mode),
         {'name': f'{image_layer.name}_farid'},
@@ -49,7 +49,7 @@ def farid_filter_widget(
         widget_init=_on_init
         )
 def prewitt_filter_widget(
-    image_layer: Image, mode='reflect') -> napari.types.LayerDataTuple:
+    image_layer: Image, mode: str ='reflect') -> napari.types.LayerDataTuple:
     return (
         sf.prewitt(image_layer.data, mode=mode),
         {'name': f'{image_layer.name}_prewitt'},
@@ -78,7 +78,7 @@ def gaussian_filter_widget(
     img_layer: Image,
     sigma: float = 1.0,
     preserve_range: bool = False,
-    mode = "reflect",
+    mode: str = "reflect",
 ) -> napari.types.LayerDataTuple:
     return (
         sf.gaussian(img_layer.data, sigma=sigma, preserve_range=preserve_range, mode=mode),
@@ -96,7 +96,7 @@ def frangi_filter_widget(
     scale_start: float = 1.0,
     scale_end: float = 10.0,
     scale_step: float = 2.0,
-    mode = "reflect",
+    mode: str = "reflect",
     black_ridges: bool = True,
 ) -> napari.types.LayerDataTuple:
     return (


### PR DESCRIPTION
Hi @guiwitz ,

tiny little fix: I noticed that a type annotation was missing for the median filter when I was trying to auto-harvest the functions in this repo for command-line execution. The process rides crucially on correct type annotations so that'll help me :) 

Thanks for considering!

*edit*: If you don't mind, I would also change the type annotation in the `maths_image_pairs_widget` from `Layer` to `Union[Image, Labels]` as `Layer` would also allow Surfaces, Points, etc.