### PR TITLE
Add 3d morphology elements

### DIFF
--- a/src/napari_skimage/skimage_morphology_widget.py
+++ b/src/napari_skimage/skimage_morphology_widget.py
@@ -39,7 +39,8 @@ def _on_init(widget):
 @magic_factory(
     label_layer={'label': 'Labels'},
     method={'choices': ['erosion', 'dilation', 'opening', 'closing']},
-    footprint={'label': 'Footprint', 'choices': ['disk', 'square', 'diamond', 'star', 'octagon']},
+    footprint={'label': 'Footprint', 'choices': ['disk', 'square',
+                                                 'diamond', 'star', 'octagon', 'ball', 'cube']},
     footprint_size={'label': 'Footprint size', 'max': 100, 'min': 1, 'step': 1},
     # to add for skimage 0.23
     #mode = {'choices': ['min', 'max', 'ignore']},
@@ -54,8 +55,17 @@ def binary_morphology_widget(
     #mode = "ignore"
 ) -> napari.types.LayerDataTuple:
     fun = getattr(sm, f'binary_{method}')
-    fun_footprint = getattr(sm, footprint)
-    selem = fun_footprint(footprint_size)
+    if footprint == 'cube':
+        selem = sm.footprint_rectangle((footprint_size, footprint_size, footprint_size))
+    else:
+        fun_footprint = getattr(sm, footprint)
+        selem = fun_footprint(footprint_size)
+
+    if (label_layer.data.ndim == 3) and (selem.ndim == 2):
+        raise ValueError("For 3D data, selem needs to be 'ball")
+    if (label_layer.data.ndim == 2) and (selem.ndim == 3):
+        raise ValueError("For 2D data, selem cannot be 'ball'")
+
     mask = fun(label_layer.data, selem)#, mode=mode)
     return (
         mask,
@@ -66,7 +76,8 @@ def binary_morphology_widget(
     label_layer={'label': 'Image'},
     method={'choices': ['erosion', 'dilation', 'opening', 'closing',
                         'white_tophat', 'black_tophat']},
-    footprint={'label': 'Footprint', 'choices': ['disk', 'square', 'diamond', 'star', 'octagon']},
+    footprint={'label': 'Footprint', 'choices': ['disk', 'square', 
+                                                 'diamond', 'star', 'octagon', 'ball', 'cube']},
     footprint_size={'label': 'Footprint size', 'max': 100, 'min': 1, 'step': 1},
     # to add for skimage 0.23
     # mode = {'choices': ['reflect', 'constant', 'nearest0', 'mirror', 'wrap', 'max', 'min', 'ignore']},
@@ -81,8 +92,17 @@ def morphology_widget(
     #mode = "ignore"
 ) -> napari.types.LayerDataTuple:
     fun = getattr(sm, f'{method}')
-    fun_footprint = getattr(sm, footprint)
-    selem = fun_footprint(footprint_size)
+    if footprint == 'cube':
+        selem = sm.footprint_rectangle((footprint_size, footprint_size, footprint_size))
+    else:
+        fun_footprint = getattr(sm, footprint)
+        selem = fun_footprint(footprint_size)
+
+    if (label_layer.data.ndim == 3) and (selem.ndim == 2):
+        raise ValueError("For 3D data, selem needs to be 'ball")
+    if (label_layer.data.ndim == 2) and (selem.ndim == 3):
+        raise ValueError("For 2D data, selem cannot be 'ball'")
+    
     mask = fun(label_layer.data, selem)#, mode=mode)
     return (
         mask,


### PR DESCRIPTION
This PR adds ball and cube as structuring elements for 3D morphological operations. Note that cube is not directly available from `skimage.morphology` but that `footprint_rectangle` with same size in xyz is used for that.