### PR TITLE
Watershed

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,13 +7,11 @@ on:
   push:
     branches:
       - main
-      - npe2
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     branches:
       - main
-      - npe2
   workflow_dispatch:
 
 jobs:
@@ -24,68 +22,55 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Setup python
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          activate-environment: "true"
 
-      # these libraries enable testing on Qt on linux
-      - uses: tlambert03/setup-qt-libs@v1
-
-      # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
-        if: runner.os == 'Windows'
-        run: |
-          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
-          powershell gl-ci-helpers/appveyor/install_opengl.ps1
-
-      # note: if you need dependencies from conda, considering using
-      # setup-miniconda: https://github.com/conda-incubator/setup-miniconda
-      # and
-      # tox-conda: https://github.com/tox-dev/tox-conda
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install setuptools tox tox-gh-actions
-
-      # this runs the platform-specific tests declared in tox.ini
-      - name: Test with tox
-        uses: aganders3/headless-gui@v1
+        uses: pyvista/setup-headless-display-action@v4.2
         with:
-          run: python -m tox
+          qt: true
+          wm: herbstluftwm
+
+      - name: Test with tox
+        run: uvx --with tox-gh-actions tox -- ${{ matrix.group.files }}
         env:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true  # reliable tokenless codecov uploads
+
+  build-and-inspect-package:
+    name: Build & inspect package.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hynek/build-and-inspect-python-package@v2
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
     # and requires that you have put your twine API key in your
     # github secrets (see readme for details)
-    needs: [test]
+    needs: [test, build-and-inspect-package]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@v7
         with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools setuptools_scm wheel twine build
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
-        run: |
-          git tag
-          python -m build .
-          twine upload dist/*
+          name: Packages
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,6 +19,8 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
+    permissions:
+      id-token: write  # needed for codecov OIDC authentication
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright (c) 2024, Guillaume Witz, Data Science Lab, University of Bern
+Copyright (c) 2026, Guillaume Witz, Data Science Lab, University of Bern
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 requires-python = ">=3.9"
@@ -69,7 +71,7 @@ write_to = "src/napari_skimage/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313', 'py314']
 
 [tool.ruff]
 line-length = 79
@@ -114,5 +116,5 @@ exclude = [
     "*_vendor*",
 ]
 
-target-version = "py38"
+target-version = "py39"
 fix = true

--- a/src/napari_skimage/__init__.py
+++ b/src/napari_skimage/__init__.py
@@ -15,8 +15,9 @@ from. mathsops import (simple_maths_widget, maths_image_pairs_widget,
                        maths_crop_widget, conversion_widget)
 from .skimage_detection_widget import (peak_local_max_widget,
                                        marching_cubes_widget,
-                                       marching_cubes_labels_widget)
-from .skimage_label_widget import label_widget
+                                       marching_cubes_labels_widget,
+                                       watershed_widget)
+from .skimage_label_widget import label_widget, points_to_label_widget
 from .axis_ops import AxisWidget
 
 __all__ = (
@@ -27,6 +28,7 @@ __all__ = (
     "frangi_filter_widget",
     "median_filter_widget",
     "butterworth_filter_widget",
+    "distance_transform_widget",
     "RankFilterWidget",
     "threshold_widget",
     "ManualThresholdWidget",
@@ -41,6 +43,8 @@ __all__ = (
     "peak_local_max_widget",
     "marching_cubes_widget",
     "marching_cubes_labels_widget",
+    "watershed_widget",
     "label_widget",
+    "points_to_label_widget",
     "AxisWidget",
 )

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -27,6 +27,9 @@ contributions:
     - id: napari-skimage.make_butterworth_widget
       python_name: napari_skimage.skimage_filter_widget:butterworth_filter_widget
       title: Make Butterworth filter widget
+    - id: napari-skimage.make_distance_transform_widget
+      python_name: napari_skimage.skimage_filter_widget:distance_transform_widget
+      title: Make distance transform widget
     - id: napari-skimage.make_threshold_widget
       python_name: napari_skimage.skimage_threshold_widget:threshold_widget
       title: Make threshold widget

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -42,6 +42,9 @@ contributions:
     - id: napari-skimage.make_label_widget
       python_name: napari_skimage.skimage_label_widget:label_widget
       title: Make label connected components widget
+    - id: napari-skimage.make_points_to_label_widget
+      python_name: napari_skimage.skimage_label_widget:points_to_label_widget
+      title: Make convert points to labels widget
     - id: napari-skimage.make_maths_image_pairs_widget
       python_name: napari_skimage.mathsops:maths_image_pairs_widget
       title: Make image pairs maths widget
@@ -72,6 +75,9 @@ contributions:
     - id: napari-skimage.make_marching_cubes_labels_widget
       python_name: napari_skimage.skimage_detection_widget:marching_cubes_labels_widget
       title: Make Marching Cubes (labels) widget
+    - id: napari-skimage.make_watershed_widget
+      python_name: napari_skimage.skimage_detection_widget:watershed_widget
+      title: Make Watershed widget
     - id: napari-skimage.make_regionprops_widget
       python_name: napari_skimage.skimage_regionprops_widget:regionprops_widget
       title: Make regionprops widget
@@ -95,6 +101,8 @@ contributions:
       display_name: Butterworth filter
     - command: napari-skimage.make_threshold_widget
       display_name: Automated Threshold
+    - command: napari-skimage.make_distance_transform_widget
+      display_name: Distance Transform
     - command: napari-skimage.make_manual_threshold_widget
       display_name: Manual Threshold
     - command: napari-skimage.make_binary_morphology_widget
@@ -103,6 +111,8 @@ contributions:
       display_name: Morphology
     - command: napari-skimage.make_label_widget
       display_name: Label connected components
+    - command: napari-skimage.make_points_to_label_widget
+      display_name: Convert Points to Labels
     - command: napari-skimage.make_simple_maths_widget
       display_name: Simple maths
     - command: napari-skimage.make_maths_crop_widget
@@ -123,6 +133,8 @@ contributions:
       display_name: Marching Cubes
     - command: napari-skimage.make_marching_cubes_labels_widget
       display_name: Marching Cubes (labels)
+    - command: napari-skimage.make_watershed_widget
+      display_name: Watershed
     - command: napari-skimage.make_regionprops_widget
       display_name: Regionprops (labels)
     - command: napari-skimage.make_axis_widget
@@ -143,14 +155,17 @@ contributions:
       - command: napari-skimage.make_regionprops_widget
     napari/layers/segment:
       - command: napari-skimage.make_label_widget
+      - command: napari-skimage.make_watershed_widget
     napari/layers/layer_type:
       - command: napari-skimage.make_peak_local_max_widget
       - command: napari-skimage.make_marching_cubes_widget
       - command: napari-skimage.make_marching_cubes_labels_widget
+      - command: napari-skimage.make_points_to_label_widget
     filtering_submenu:
       - command: napari-skimage.make_gaussian_widget
       - command: napari-skimage.make_median_widget
       - command: napari-skimage.make_butterworth_widget
+      - command: napari-skimage.make_distance_transform_widget
       - command: napari-skimage.make_rank_widget
     edge_subemnu:
       - command: napari-skimage.make_farid_widget

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -106,7 +106,7 @@ def watershed_widget(
     invert_image: bool = False
 ) -> napari.types.LayerDataTuple:
     
-    """We can use numpy docstrings to provide tooltips.
+    """Segment an image, typically a distance transform, using the watershed algorithm.
 
     Parameters
     ----------

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -1,4 +1,3 @@
-from email.mime import image
 from typing import TYPE_CHECKING
 import numpy as np
 from magicgui import magic_factory
@@ -9,7 +8,6 @@ from skimage.feature import peak_local_max
 from skimage.measure import marching_cubes
 from napari.layers import Image, Labels
 import napari.types
-import scipy.ndimage
 
 if TYPE_CHECKING:
     import napari
@@ -35,7 +33,6 @@ def _on_init_marching_cubes(widget):
 
 def _on_init(widget):
     label_widget = Label(value='')
-    func_name = widget.label.split(' ')[0]
     if widget.label == 'watershed widget':
         label_widget.value = f'<a href=\"https://scikit-image.org/docs/0.25.x/api/skimage.segmentation.html#skimage.segmentation.watershed\">skimage.segmentation.watershed</a>'
     elif widget.label == 'marching cubes widget' or widget.label == 'marching cubes labels widget':

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -128,4 +128,4 @@ def watershed_widget(
             image = sign * image_layer.data, markers=label_layer.data,
             mask=mask_layer.data, watershed_line=watershed_lines),
         {'name': f'{label_layer.name}_watershed'},
-        'image')
+        'labels')

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -13,30 +13,14 @@ if TYPE_CHECKING:
     import napari
 
 
-def _on_init_peak_local_max(widget):
-    label_widget = Label(value='')
-    func_name = '_'.join(widget.label.split(' ')[:-1])
-    label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.{func_name}\">skimage.feature.{func_name}</a>'
-    label_widget.native.setTextFormat(Qt.RichText)
-    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
-    label_widget.native.setOpenExternalLinks(True)
-    widget.extend([label_widget])
-
-
-def _on_init_marching_cubes(widget):
-    label_widget = Label(value='')
-    label_widget.value = '<a href=\"https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.marching_cubes\">skimage.measure.marching_cubes</a>'
-    label_widget.native.setTextFormat(Qt.RichText)
-    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
-    label_widget.native.setOpenExternalLinks(True)
-    widget.extend([label_widget])
-
 def _on_init(widget):
     label_widget = Label(value='')
     if widget.label == 'watershed widget':
         label_widget.value = f'<a href=\"https://scikit-image.org/docs/0.25.x/api/skimage.segmentation.html#skimage.segmentation.watershed\">skimage.segmentation.watershed</a>'
     elif widget.label == 'marching cubes widget' or widget.label == 'marching cubes labels widget':
         label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.marching_cubes\">skimage.measure.marching_cubes</a>'
+    elif widget.label == 'peak local max widget':
+        label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.peak_local_max\">skimage.feature.peak_local_max</a>'
     label_widget.native.setTextFormat(Qt.RichText)
     label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
     label_widget.native.setOpenExternalLinks(True)
@@ -49,7 +33,7 @@ def _on_init(widget):
     threshold_absolute={'label': 'Threshold Absolute', 'min': 0.0, 'max': 65535},
     threshold_relative={'label': 'Threshold Relative', 'min': 0.0, 'max': 1.0},
     call_button="Detect Local Maxima",
-    widget_init=_on_init_peak_local_max
+    widget_init=_on_init
 )
 def peak_local_max_widget(
     image_layer: Image,
@@ -74,7 +58,7 @@ def peak_local_max_widget(
     image_layer={'label': 'Image'},
     level={'label': 'Level', 'min': 0.0, 'max': 65535},
     call_button="Apply Marching Cubes",
-    widget_init=_on_init_marching_cubes
+    widget_init=_on_init
 )
 def marching_cubes_widget(
     image_layer: Image,
@@ -92,7 +76,7 @@ def marching_cubes_widget(
 @magic_factory(
     labels_layer={'label': 'Labels'},
     call_button='Apply Marching Cubes',
-    widget_init=_on_init_marching_cubes
+    widget_init=_on_init
 )
 def marching_cubes_labels_widget(
     labels_layer: Labels,
@@ -107,7 +91,9 @@ def marching_cubes_labels_widget(
 
 @magic_factory(
         image_layer={'label': 'Image'},
-        label_layer={'label': 'Label'},
+        label_layer={'label': 'Markers'},
+        mask_layer={'label': 'Mask'},
+        watershed_lines={'label': 'Watershed Lines'},
         invert_image={'label': 'Invert Image'},
         call_button="Apply Watershed",
         widget_init=_on_init
@@ -116,10 +102,13 @@ def watershed_widget(
     image_layer: Image,
     label_layer: Labels,
     mask_layer: Labels,
+    watershed_lines: bool = False,
     invert_image: bool = False
 ) -> napari.types.LayerDataTuple:
     sign = -1 if invert_image else 1
     return (
-        skimage.segmentation.watershed(sign * image_layer.data, markers=label_layer.data, mask=mask_layer.data),
+        skimage.segmentation.watershed(
+            image = sign * image_layer.data, markers=label_layer.data,
+            mask=mask_layer.data, watershed_line=watershed_lines),
         {'name': f'{label_layer.name}_watershed'},
         'image')

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -105,6 +105,23 @@ def watershed_widget(
     watershed_lines: bool = False,
     invert_image: bool = False
 ) -> napari.types.LayerDataTuple:
+    
+    """We can use numpy docstrings to provide tooltips.
+
+    Parameters
+    ----------
+    image_layer : napari.layers.Image
+        The image to segment, typically a distance transform or gradient image.
+    label_layer : napari.layers.Labels
+        The markers for watershed, typically a labeled image of local maxima.
+    mask_layer : napari.layers.Labels
+        A binary mask to limit the watershed segmentation.
+    watershed_lines : bool, optional
+        Whether to include watershed lines in the output, by default False.
+    invert_image : bool, optional
+        Whether to invert the image before watershed, typically used when segmenting from a distance transform, by default False.
+
+    """
     sign = -1 if invert_image else 1
     return (
         skimage.segmentation.watershed(

--- a/src/napari_skimage/skimage_detection_widget.py
+++ b/src/napari_skimage/skimage_detection_widget.py
@@ -1,12 +1,15 @@
+from email.mime import image
 from typing import TYPE_CHECKING
 import numpy as np
 from magicgui import magic_factory
 from qtpy.QtCore import Qt
 from magicgui.widgets import Label
+import skimage
 from skimage.feature import peak_local_max
 from skimage.measure import marching_cubes
 from napari.layers import Image, Labels
 import napari.types
+import scipy.ndimage
 
 if TYPE_CHECKING:
     import napari
@@ -25,6 +28,18 @@ def _on_init_peak_local_max(widget):
 def _on_init_marching_cubes(widget):
     label_widget = Label(value='')
     label_widget.value = '<a href=\"https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.marching_cubes\">skimage.measure.marching_cubes</a>'
+    label_widget.native.setTextFormat(Qt.RichText)
+    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label_widget.native.setOpenExternalLinks(True)
+    widget.extend([label_widget])
+
+def _on_init(widget):
+    label_widget = Label(value='')
+    func_name = widget.label.split(' ')[0]
+    if widget.label == 'watershed widget':
+        label_widget.value = f'<a href=\"https://scikit-image.org/docs/0.25.x/api/skimage.segmentation.html#skimage.segmentation.watershed\">skimage.segmentation.watershed</a>'
+    elif widget.label == 'marching cubes widget' or widget.label == 'marching cubes labels widget':
+        label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.marching_cubes\">skimage.measure.marching_cubes</a>'
     label_widget.native.setTextFormat(Qt.RichText)
     label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
     label_widget.native.setOpenExternalLinks(True)
@@ -92,3 +107,22 @@ def marching_cubes_labels_widget(
         {'name': f'{labels_layer.name}_surface'},
         'surface'
     )
+
+@magic_factory(
+        image_layer={'label': 'Image'},
+        label_layer={'label': 'Label'},
+        invert_image={'label': 'Invert Image'},
+        call_button="Apply Watershed",
+        widget_init=_on_init
+)
+def watershed_widget(
+    image_layer: Image,
+    label_layer: Labels,
+    mask_layer: Labels,
+    invert_image: bool = False
+) -> napari.types.LayerDataTuple:
+    sign = -1 if invert_image else 1
+    return (
+        skimage.segmentation.watershed(sign * image_layer.data, markers=label_layer.data, mask=mask_layer.data),
+        {'name': f'{label_layer.name}_watershed'},
+        'image')

--- a/src/napari_skimage/skimage_filter_widget.py
+++ b/src/napari_skimage/skimage_filter_widget.py
@@ -1,4 +1,3 @@
-from re import I, L
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -9,7 +8,7 @@ import scipy
 import scipy.ndimage
 import skimage.filters as sf
 import skimage.morphology as sm
-from napari.layers import Image, Labels, Layer
+from napari.layers import Image, Layer
 import napari.types
 
 

--- a/src/napari_skimage/skimage_filter_widget.py
+++ b/src/napari_skimage/skimage_filter_widget.py
@@ -1,12 +1,15 @@
+from re import I, L
 from typing import TYPE_CHECKING
 
 import numpy as np
 from magicgui import magic_factory
 from magicgui.widgets import Button, Container, create_widget, Label
 from qtpy.QtCore import Qt
+import scipy
+import scipy.ndimage
 import skimage.filters as sf
 import skimage.morphology as sm
-from napari.layers import Image
+from napari.layers import Image, Labels, Layer
 import napari.types
 
 
@@ -23,7 +26,10 @@ RankFilterWidget is a class that defines a widget for rank filters. The widget c
 def _on_init(widget):
     label_widget = Label(value='')
     func_name = widget.label.split(' ')[0]
-    label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.{func_name}\">skimage.filters.{func_name}</a>'
+    if widget.label == 'distance transform widget':
+        label_widget.value = f'<a href=\"https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.distance_transform_edt.html\">scipy.ndimage.distance_transform_edt</a>'
+    else:
+        label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.{func_name}\">skimage.filters.{func_name}</a>'
     label_widget.native.setTextFormat(Qt.RichText)
     label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
     label_widget.native.setOpenExternalLinks(True)
@@ -147,6 +153,20 @@ def butterworth_filter_widget(
     return (
         img_filtered,
         {'name': f'{img_layer.name}_butterworth'},
+        'image')
+
+@magic_factory(
+        layer={'label': 'Labels or Image'},
+        call_button="Apply Distance Transform",
+        widget_init=_on_init
+)
+def distance_transform_widget(
+    layer: Layer,
+    sampling: float = 1.0,
+) -> napari.types.LayerDataTuple:
+    return (
+        scipy.ndimage.distance_transform_edt(layer.data, sampling=sampling),
+        {'name': f'{layer.name}_distance_transform'},
         'image')
 
 class RankFilterWidget(Container):

--- a/src/napari_skimage/skimage_label_widget.py
+++ b/src/napari_skimage/skimage_label_widget.py
@@ -3,10 +3,11 @@ from typing import TYPE_CHECKING
 import napari.types
 from magicgui import magic_factory
 from magicgui.widgets import Label
-from napari.layers import Labels
+from napari.layers import Image, Labels, Points
 from napari.utils.notifications import show_info
 from qtpy.QtCore import Qt
 from skimage.measure import label
+import skimage.util
 
 if TYPE_CHECKING:
     import napari
@@ -36,6 +37,18 @@ def _on_init_label(widget: "Widget") -> None:
 
     update_connectivity_range(None)  # Initialize the range
 
+def _on_init(widget):
+    label_widget = Label(value='')
+    func_name = widget.label.split(' ')[0]
+    if widget.label == 'points to label widget':
+        label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.util.html#skimage.util.label_points\">skimage.util.label_points</a>'
+    else:
+        label_widget.value = 'None'
+    label_widget.native.setTextFormat(Qt.RichText)
+    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label_widget.native.setOpenExternalLinks(True)
+    widget.extend([label_widget])
+
 
 @magic_factory(
     labels_layer={"label": "Labels Layer"},
@@ -60,3 +73,21 @@ def label_widget(
         {"name": f"{labels_layer.name}_labeled"},
         "labels",
     )
+
+@magic_factory(
+    points_layer={"label": "Points Layer"},
+    image_layer={"label": "Image Layer"},
+    call_button="Convert Points to Labels",
+    widget_init=_on_init,
+)
+def points_to_label_widget(
+    points_layer: Points,
+    image_layer: Image,
+) -> napari.types.LayerDataTuple:
+    labeled_points = skimage.util.label_points(points_layer.data, image_layer.data.shape)
+    return (
+        (labeled_points,),
+        {"name": f"{points_layer.name}_labeled"},
+        "labels",
+    )
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312}-{linux,macos,windows}
+envlist = py{39,310,311,312,313,314}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
@@ -9,6 +9,8 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
By popular request #12, this PR adds the watershed segmentation from scikit-image. To be able to run it properly step by step the PR provides:
- a distance transform widget: this takes either an image or a labels layer as input
- a points to labels widget: this takes a point layer and an image layer as input in order to create a labels layer of appropriate size
- a watershed widget: this takes an image to segment, a labels layer with seeds, and labels layer as mask.

A user can segment blobs with the following steps:
1. Import an image
2. Compute the distance transform via widget `Distance Transform`
3. Find local maxima via widget `Peak Local Max`
4. Transform the detected locations into a mask via widget `Convert Points to Labels`
5. Threshold the image using one of the threshold methods
6. Segment the image using the `Watershed` widget and the outputs of the previous operations.

In the end it looks like something like this:
<img width="1904" height="1195" alt="Screenshot 2026-03-25 at 17 29 01" src="https://github.com/user-attachments/assets/eeb84b21-695d-4056-a7f7-bdc6653cc03f" />