### PR TITLE
Small objects

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![tests](https://github.com/guiwitz/napari-skimage/workflows/tests/badge.svg)](https://github.com/guiwitz/napari-skimage/actions)
 [![codecov](https://codecov.io/gh/guiwitz/napari-skimage/branch/main/graph/badge.svg)](https://codecov.io/gh/guiwitz/napari-skimage)
 [![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-skimage)](https://napari-hub.org/plugins/napari-skimage)
-[![launch - renku](https://renkulab.io/renku-badge.svg)](https://renkulab.io/projects/guillaume.witz1/napari-skimage/sessions/new?autostart=1)
 
 napari-skimage gives easy access to scikit-image functions in napari. The main goal of the plugin is to allow new users of napari, especially without coding experience, to easily explore basic image processing, in a similar way to what is possible in Fiji.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -71,7 +69,7 @@ write_to = "src/napari_skimage/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313', 'py314']
+target-version = ['py311', 'py312', 'py313', 'py314']
 
 [tool.ruff]
 line-length = 79
@@ -116,5 +114,5 @@ exclude = [
     "*_vendor*",
 ]
 
-target-version = "py39"
+target-version = "py311"
 fix = true

--- a/src/napari_skimage/__init__.py
+++ b/src/napari_skimage/__init__.py
@@ -8,7 +8,8 @@ from .skimage_filter_widget import (farid_filter_widget, prewitt_filter_widget,
                                     frangi_filter_widget, median_filter_widget,
                                     butterworth_filter_widget, RankFilterWidget)
 from .skimage_threshold_widget import threshold_widget, ManualThresholdWidget
-from .skimage_morphology_widget import (binary_morphology_widget, morphology_widget)
+from .skimage_morphology_widget import (binary_morphology_widget, morphology_widget,
+                                         remove_small_objects_widget)
 from .skimage_restoration_widget import (rolling_ball_restoration_widget,
                                          denoise_nl_means_restoration_widget)
 from. mathsops import (simple_maths_widget, maths_image_pairs_widget,
@@ -34,6 +35,7 @@ __all__ = (
     "ManualThresholdWidget",
     "binary_morphology_widget",
     "morphology_widget",
+    "remove_small_objects_widget",
     "rolling_ball_restoration_widget",
     "denoise_nl_means_restoration_widget",
     "simple_maths_widget",

--- a/src/napari_skimage/_tests/test_basic_widgets.py
+++ b/src/napari_skimage/_tests/test_basic_widgets.py
@@ -3,7 +3,8 @@ import numpy as np
 
 from napari_skimage.skimage_morphology_widget import (
     binary_morphology_widget,
-    morphology_widget
+    morphology_widget,
+    remove_small_objects_widget,
 )
 from napari_skimage.skimage_threshold_widget import threshold_widget, ManualThresholdWidget
 import napari_skimage.skimage_filter_widget as sfw
@@ -86,6 +87,29 @@ def test_morphology_widget(make_napari_viewer):
 
         filtered, _, _ = my_widget(viewer.layers[0])
         assert filtered.data.shape == random_image.shape
+
+
+def test_remove_small_objects_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+    labels = np.array(
+        [
+            [0, 0, 0, 0, 0],
+            [0, 1, 0, 2, 2],
+            [0, 0, 0, 2, 2],
+            [0, 0, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    layer = viewer.add_labels(labels, name='labels')
+
+    my_widget = remove_small_objects_widget()
+    filtered, metadata, layer_type = my_widget(layer, max_size=2, connectivity=1)
+
+    # Small single-pixel label is removed, larger 2x2 label is preserved.
+    assert filtered[1, 1] == 0
+    assert np.all(filtered[1:3, 3:5] == 2)
+    assert metadata['name'] == 'labels_remove_small_objects'
+    assert layer_type == 'labels'
 
 def test_thresholding_widget(make_napari_viewer):
     viewer = make_napari_viewer()

--- a/src/napari_skimage/napari.yaml
+++ b/src/napari_skimage/napari.yaml
@@ -45,6 +45,9 @@ contributions:
     - id: napari-skimage.make_label_widget
       python_name: napari_skimage.skimage_label_widget:label_widget
       title: Make label connected components widget
+    - id: napari-skimage.make_remove_small_objects_widget
+      python_name: napari_skimage.skimage_morphology_widget:remove_small_objects_widget
+      title: Make remove small objects widget
     - id: napari-skimage.make_points_to_label_widget
       python_name: napari_skimage.skimage_label_widget:points_to_label_widget
       title: Make convert points to labels widget
@@ -112,6 +115,8 @@ contributions:
       display_name: Binary Morphology
     - command: napari-skimage.make_morphology_widget
       display_name: Morphology
+    - command: napari-skimage.make_remove_small_objects_widget
+      display_name: Remove small objects
     - command: napari-skimage.make_label_widget
       display_name: Label connected components
     - command: napari-skimage.make_points_to_label_widget
@@ -146,7 +151,7 @@ contributions:
   menus:
     napari/layers/filter:
       - submenu: filtering_submenu
-      - submenu: edge_subemnu
+      - submenu: edge_submenu
       - submenu: ridge_submenu
       - submenu: denoising_submenu
       - submenu: thresholding_submenu
@@ -170,7 +175,7 @@ contributions:
       - command: napari-skimage.make_butterworth_widget
       - command: napari-skimage.make_distance_transform_widget
       - command: napari-skimage.make_rank_widget
-    edge_subemnu:
+    edge_submenu:
       - command: napari-skimage.make_farid_widget
       - command: napari-skimage.make_prewitt_widget
       - command: napari-skimage.make_laplace_widget
@@ -185,6 +190,7 @@ contributions:
     morphology_submenu:
       - command: napari-skimage.make_binary_morphology_widget
       - command: napari-skimage.make_morphology_widget
+      - command: napari-skimage.make_remove_small_objects_widget
     maths_submenu:
       - command: napari-skimage.make_simple_maths_widget
       - command: napari-skimage.make_maths_image_pairs_widget
@@ -193,7 +199,7 @@ contributions:
   submenus:
     - id: filtering_submenu
       label: Filtering
-    - id: edge_subemnu
+    - id: edge_submenu
       label: Edge detection
     - id: ridge_submenu
       label: Ridge detection

--- a/src/napari_skimage/skimage_filter_widget.py
+++ b/src/napari_skimage/skimage_filter_widget.py
@@ -34,6 +34,23 @@ def _on_init(widget):
     label_widget.native.setOpenExternalLinks(True)
     widget.extend([label_widget])
 
+def _on_init_median(widget):
+    _on_init(widget)
+    def update_properties_choices(event: object) -> None:
+        if widget.img_layer.value is None:
+            widget.footprint._default_choices = []
+        elif widget.img_layer.value.data.ndim == 2:
+            widget.footprint._default_choices = ['disk', 'square', 'diamond', 'star', 'octagon']
+        elif widget.img_layer.value.data.ndim == 3:
+            widget.footprint._default_choices = ['ball']
+        else:
+            widget.footprint._default_choices = []
+        widget.footprint.reset_choices()
+
+    widget.img_layer.changed.connect(update_properties_choices)
+    update_properties_choices(widget)
+    
+
 @magic_factory(
         image_layer={'label': 'Image'},
         mode={'choices': ['reflect', 'constant', 'nearest', 'mirror', 'wrap']},
@@ -116,7 +133,7 @@ def frangi_filter_widget(
     footprint={'label': 'Footprint', 'choices': ['disk', 'square', 'diamond', 'star', 'octagon']},
     footprint_size={'label': 'Footprint size', 'max': 100, 'min': 1, 'step': 1},
     call_button="Apply operation",
-    widget_init=_on_init
+    widget_init=_on_init_median
 )
 def median_filter_widget(
     img_layer: Image,

--- a/src/napari_skimage/skimage_morphology_widget.py
+++ b/src/napari_skimage/skimage_morphology_widget.py
@@ -109,18 +109,45 @@ def morphology_widget(
         {'name': f'{label_layer.name}_{method}'},
         'image')
 
+
+def _on_init2(widget):
+    label_widget = Label(value='')
+    func_name = widget.label.split(' ')[0]
+    label_widget.value = f'<a href=\"https://scikit-image.org/docs/stable/api/skimage.morphology.html#skimage.morphology.{func_name}\">skimage.morphology.{func_name}</a>'
+    label_widget.native.setTextFormat(Qt.RichText)
+    label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
+    label_widget.native.setOpenExternalLinks(True)
+    widget.extend([label_widget])
+
 @magic_factory(
     label_layer={'label': 'Labels'},
-    max_size={'label': 'max_size', 'max': 100, 'min': 1, 'step': 1},
+    max_size={'label': 'max_size', 'value': 64, 'min': 0, 'max': 2_147_483_647},
     connectivity={'label': 'connectivity', 'max': 3, 'min': 1, 'step': 1},
     call_button="Apply operation",
-    widget_init=_on_init
+    widget_init=_on_init2
 )
 def remove_small_objects_widget(
     label_layer: Labels,
     max_size = 64,
     connectivity = 1,
 ) -> napari.types.LayerDataTuple:
+    """Remove small objects from a labeled image.
+
+    Parameters
+    ----------
+    label_layer : napari.layers.Labels
+        The labeled image from which to remove small objects.
+    max_size : int, optional
+        The maximum size of objects to keep, by default 64.
+    connectivity : int, optional
+        The connectivity defining the neighborhood of a pixel, by default 1.
+
+    Returns
+    -------
+    napari.types.LayerDataTuple
+        The labeled image with small objects removed.
+    """
+    
     mask = sm.remove_small_objects(label_layer.data, max_size=max_size, connectivity=connectivity)
     return (
         mask,

--- a/src/napari_skimage/skimage_morphology_widget.py
+++ b/src/napari_skimage/skimage_morphology_widget.py
@@ -108,3 +108,21 @@ def morphology_widget(
         mask,
         {'name': f'{label_layer.name}_{method}'},
         'image')
+
+@magic_factory(
+    label_layer={'label': 'Labels'},
+    max_size={'label': 'max_size', 'max': 100, 'min': 1, 'step': 1},
+    connectivity={'label': 'connectivity', 'max': 3, 'min': 1, 'step': 1},
+    call_button="Apply operation",
+    widget_init=_on_init
+)
+def remove_small_objects_widget(
+    label_layer: Labels,
+    max_size = 64,
+    connectivity = 1,
+) -> napari.types.LayerDataTuple:
+    mask = sm.remove_small_objects(label_layer.data, max_size=max_size, connectivity=connectivity)
+    return (
+        mask,
+        {'name': f'{label_layer.name}_remove_small_objects'},
+        'labels')

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312,313,314}-{linux,macos,windows}
+envlist = py{311,312,313,314}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.9: py39
-    3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313


### PR DESCRIPTION
This PR:
- Adds a widget for `skimage.morphology.remove_small_objects`. Solves #24 
- Removes support for Python 3.9 and 3.10 to be aligned with scikit-image. Main reason for this drop is a change in the call to `remove_small_objects` from older versions of scikit-image not available in modern Python versions
- Adds option to use a 3D Ball in median filter. Previously, only 2D filtering was supported. FIxes #19 